### PR TITLE
Add link directly to code for the available options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Use only one src and one dest, apiDoc search in subdirs for files with apidoc-pa
 
 ### Additional options
 
-All `apiDoc` options can be used within options-block, see [apiDoc configure](http://apidocjs.com/#configure) for details.
+All `apiDoc` options can be used within options-block, see [apiDoc configure](http://apidocjs.com/#configure) for details,
+or look [directly at the code](https://github.com/apidoc/apidoc/blob/master/lib/index.js#L10-L22).
 
 * <code>src:</code> Source files directory.
 * <code>dest:</code> Destination directory, where the documentation will be created.


### PR DESCRIPTION
I wasn't able to easily see the available options from the link provided.  I looked at the code, and found the `defaults` map to incredibly valuable.

The available options (e.g. `markdown`, or `config`) might be better documented directly in the apidoc, but regardless I wanted to push this PR to possibly save someone some hassle in the future.

<img width="702" alt="screen shot 2016-01-05 at 1 16 19 pm" src="https://cloud.githubusercontent.com/assets/48086/12123418/da669cce-b3ae-11e5-8904-5db0570edf26.png">
